### PR TITLE
Fix duplicate hash transform functions

### DIFF
--- a/data-product/pinot-tables/payment-analytics-view.json
+++ b/data-product/pinot-tables/payment-analytics-view.json
@@ -148,22 +148,6 @@
         {
           "columnName": "transactionTime",
           "transformFunction": "COALESCE(registeredAt, bookedAt)"
-        },
-        {
-          "columnName": "buyerEmail",
-          "transformFunction": "hash(buyerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "sellerEmail",
-          "transformFunction": "hash(sellerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "buyerName",
-          "transformFunction": "hash(buyerName, 'SHA256')"
-        },
-        {
-          "columnName": "sellerName",
-          "transformFunction": "hash(sellerName, 'SHA256')"
         }
       ]
     }

--- a/data-product/pinot-tables/transaction-booked-offline-table.json
+++ b/data-product/pinot-tables/transaction-booked-offline-table.json
@@ -119,27 +119,7 @@
             }
           }
         }
-      ]
-    },
-    "transformConfig": {
-      "transformFunctions": [
-        {
-          "columnName": "buyerEmail",
-          "transformFunction": "hash(buyerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "sellerEmail",
-          "transformFunction": "hash(sellerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "buyerName",
-          "transformFunction": "hash(buyerName, 'SHA256')"
-        },
-        {
-          "columnName": "sellerName",
-          "transformFunction": "hash(sellerName, 'SHA256')"
-        }
-      ]
+            ]
     }
   },
   "tierConfigs": [

--- a/data-product/pinot-tables/transaction-wallet-registered-offline-table.json
+++ b/data-product/pinot-tables/transaction-wallet-registered-offline-table.json
@@ -111,27 +111,7 @@
             }
           }
         }
-      ]
-    },
-    "transformConfig": {
-      "transformFunctions": [
-        {
-          "columnName": "buyerEmail",
-          "transformFunction": "hash(buyerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "sellerEmail",
-          "transformFunction": "hash(sellerEmail, 'SHA256')"
-        },
-        {
-          "columnName": "buyerName",
-          "transformFunction": "hash(buyerName, 'SHA256')"
-        },
-        {
-          "columnName": "sellerName",
-          "transformFunction": "hash(sellerName, 'SHA256')"
-        }
-      ]
+            ]
     }
   },
   "tierConfigs": [


### PR DESCRIPTION
Remove duplicate hash transform functions for PII fields in Pinot offline table configurations to prevent double hashing.