### PR TITLE
Fix duplicate PII hashing transformations

### DIFF
--- a/data-product/pinot-tables/transaction-wallet-registered-offline-table.json
+++ b/data-product/pinot-tables/transaction-wallet-registered-offline-table.json
@@ -77,23 +77,19 @@
     },
     {
       "name": "buyerEmail",
-      "encodingType": "DICTIONARY",
-      "transformFunction": "hash(buyerEmail, 'SHA256')"
+      "encodingType": "DICTIONARY"
     },
     {
       "name": "sellerEmail",
-      "encodingType": "DICTIONARY", 
-      "transformFunction": "hash(sellerEmail, 'SHA256')"
+      "encodingType": "DICTIONARY"
     },
     {
       "name": "buyerName",
-      "encodingType": "DICTIONARY",
-      "transformFunction": "hash(buyerName, 'SHA256')"
+      "encodingType": "DICTIONARY"
     },
     {
       "name": "sellerName",
-      "encodingType": "DICTIONARY",
-      "transformFunction": "hash(sellerName, 'SHA256')"
+      "encodingType": "DICTIONARY"
     }
   ],
   "ingestionConfig": {


### PR DESCRIPTION
Remove duplicate PII hashing transformations from `fieldConfigList` to prevent double hashing.